### PR TITLE
feat(blog): Platform Engineering 2026 – Warum IDPs DevOps ablösen

### DIFF
--- a/src/content/blog/platform-engineering-2026.md
+++ b/src/content/blog/platform-engineering-2026.md
@@ -1,0 +1,73 @@
+---
+title: "Platform Engineering 2026: Warum Internal Developer Platforms DevOps ablösen"
+description: "Platform Engineering ist 2026 kein Hype mehr – es ist strategische Notwendigkeit. Warum Unternehmen auf Internal Developer Platforms setzen und was das für eure Cloud-Strategie bedeutet."
+pubDate: "Jun 26 2026"
+heroImage: "/placeholder-hero.jpg"
+author: "andre-lademann"
+---
+
+Die Zahlen sprechen eine klare Sprache: Laut Gartner werden bis Ende 2026 über **80% aller Software-Engineering-Organisationen** dedizierte Platform Teams haben. Noch 2023 war Platform Engineering ein Begriff, den viele CIOs bestenfalls vom Hörensagen kannten. Heute ist es die Antwort auf eine der drängendsten Fragen im Cloud-Zeitalter: Wie behalten Entwicklungsteams ihre Produktivität, wenn die Infrastrukturkomplexität exponentiell wächst?
+
+## Das Problem mit klassischem DevOps
+
+DevOps war die richtige Antwort auf die falschen Strukturen der 2010er-Jahre. Silos aufbrechen, Entwicklung und Betrieb zusammenbringen, Deployments beschleunigen – das hat funktioniert. Bis Kubernetes kam.
+
+Mit Kubernetes bekamen Teams plötzlich immense Kontrolle über ihre Infrastruktur. Aber Kontrolle hat ihren Preis: Ingress-Controller konfigurieren, Service Meshes debuggen, RBAC-Berechtigungen verwalten, Storage provisioning, Observability-Stacks aufsetzen – all das landet bei den Entwicklern. Das Ergebnis: Developer verbringen mehr Zeit mit Infrastruktur als mit dem Produkt, das sie eigentlich bauen sollen.
+
+In einer aktuellen Studie geben über **60% der Entwickler** an, dass Infrastrukturaufgaben ihre Produktivität signifikant beeinträchtigen. Die DevOps-Philosophie "you build it, you run it" funktioniert prima für kleine Teams. Für Organisationen mit 50, 100 oder 500 Engineers wird sie zur Bremse.
+
+## Was Platform Engineering anders macht
+
+Platform Engineering dreht den Ansatz um: Statt jeden Entwickler zum Infrastruktur-Experten zu machen, baut ein spezialisiertes Platform Team eine **Internal Developer Platform (IDP)** – und behandelt diese Plattform wie ein Produkt.
+
+Eine gut gebaute IDP abstrahiert die Kubernetes-Komplexität unter einer klaren, self-service-fähigen Oberfläche. Entwickler wählen aus vorab genehmigten Templates ("Golden Paths"), provisionieren Umgebungen auf Knopfdruck und deployen mit integrierten Security-Guardrails und Observability – ohne jemals eine YAML-Datei anfassen zu müssen.
+
+Das klingt nach Komfort-Feature. Es ist in Wahrheit ein strategischer Hebel:
+
+- **30–50% schnellere Deployment-Zyklen** in Organisationen mit reifer IDP (Quelle: DORA Report 2025)
+- **40–50% höhere Developer Productivity** durch weniger kognitive Last
+- Signifikant niedrigere Fehlerquoten durch standardisierte, getestete Deployment-Pfade
+
+## Die Technologie dahinter
+
+Das Herzstück moderner IDPs ist meist ein Portal wie **Backstage** (Open Source, ursprünglich von Spotify), kombiniert mit GitOps-Automatisierung über ArgoCD oder Flux. Kubernetes bleibt das Fundament – aber eben als Plattform für die Plattform, nicht als tägliches Werkzeug für jeden Entwickler.
+
+Ein typischer Stack sieht 2026 so aus:
+
+- **Self-Service Portal:** Backstage oder ein Custom-Frontend
+- **GitOps-Layer:** ArgoCD + Helm oder Kustomize
+- **Policy Enforcement:** OPA/Gatekeeper, Kyverno
+- **Secrets Management:** HashiCorp Vault oder Azure Key Vault
+- **Observability:** OpenTelemetry + Grafana Stack oder Azure Monitor
+- **Cost Visibility:** FinOps-Integration mit Cloud Cost APIs
+
+Was auf dem Papier komplex wirkt, zahlt sich aus: Teams deployen mehrmals täglich, Onboarding neuer Entwickler dauert Stunden statt Wochen, und Security-Anforderungen sind von Anfang an Teil des Prozesses – nicht nachträgliche Aufgabe des Security-Teams.
+
+## AI-native Operations: Der nächste Schritt
+
+Wer 2026 eine IDP baut, ohne AI zu berücksichtigen, baut bereits veraltet. **92% der CIOs** planen laut aktuellen Umfragen AI-Integrationen in ihre Entwicklungsplattformen.
+
+In der Praxis bedeutet das: Anomalie-Erkennung in der Observability, intelligentes Auto-Scaling auf Basis von Lastmustern, KI-gestützte Code-Reviews in der CI/CD-Pipeline und natürlich AI-Assistenten direkt im IDP-Portal. Kubernetes hat sich dabei von einem Container-Orchestrator zur **AI-Infrastrukturplattform** entwickelt – 66% der Organisationen führen bereits generative AI-Workloads auf Kubernetes aus.
+
+## Was das für eure Cloud-Strategie bedeutet
+
+Platform Engineering ist kein Projekt – es ist eine organisatorische Entscheidung. Wer damit startet, sollte drei Dinge von Anfang an richtig machen:
+
+**1. Klein anfangen, groß denken**
+Kein Platform Team schafft sofort eine vollständige IDP. Startet mit dem größten Pain Point eurer Entwickler – oft ist das Environment Provisioning oder CI/CD-Standardisierung. Baut darauf auf.
+
+**2. Developer Experience als Produkt behandeln**
+Das Platform Team muss die Entwickler als interne Kunden sehen. Das bedeutet: User Research, regelmäßiges Feedback, Iterations-Zyklen. Eine IDP, die niemand nutzt, ist wertlos.
+
+**3. Security und FinOps von Tag eins integrieren**
+Golden Paths müssen sicher sein und Kostentransparenz mitbringen. Policies as Code verhindern, dass Entwickler aus Versehen unsichere Deployments durchbringen – ohne sie auszubremsen.
+
+## Fazit: Die Frage ist nicht ob, sondern wann
+
+Unternehmen, die heute in Platform Engineering investieren, bauen den Vorsprung aus, den sie in zwei Jahren brauchen. Die Konkurrenz schläft nicht – und die besten Entwickler wählen Arbeitgeber, bei denen sie produktiv sind, nicht solche, bei denen sie Kubernetes-YAMLs debuggen.
+
+Bei Thinkport helfen wir Organisationen dabei, den Einstieg in Platform Engineering pragmatisch zu gestalten: Von der IDP-Strategie über die Kubernetes-Infrastruktur bis zur GitOps-Automatisierung. Sprecht uns an – wir zeigen euch, was in eurem Kontext wirklich funktioniert.
+
+---
+
+> Dieser Artikel basiert auf aktuellen Marktdaten (Gartner, DORA Report 2025, CNCF Survey 2025) und Thinkport-Projekterfahrungen. Erstellt von Andre Lademann.


### PR DESCRIPTION
## Blog Post: Platform Engineering 2026

**Autor:** andre-lademann
**Datum:** 26. Juni 2026
**Datei:** `src/content/blog/platform-engineering-2026.md`

### Zusammenfassung

Neuer Weekly Blog Post zum aktuellen Trend Platform Engineering / Internal Developer Platforms (IDPs). Das Thema ist gerade hochaktuell (Gartner: 80% aller Orgs haben bis 2026 dedizierte Platform Teams) und passt perfekt zur Thinkport-Positionierung als Cloud Consulting Partner.

### Inhalt

- Warum klassisches DevOps an seine Grenzen stößt
- Was Platform Engineering anders macht (IDPs, Golden Paths, Self-Service)
- Der typische Tech-Stack 2026 (Backstage, ArgoCD, OPA, OpenTelemetry)
- AI-native Operations als nächster Schritt
- Handlungsempfehlungen für die Cloud-Strategie

### Themen-Relevanz

Recherchiert auf Basis aktueller Quellen (Gartner, DORA Report 2025, CNCF Survey 2025, InfoQ, Fairwinds).

### Image Prompt (für Hero Image)

> A futuristic developer portal interface floating above a Kubernetes cluster visualization, blue and purple gradient, clean minimal tech aesthetic, isometric 3D illustration style

### Checklist

- [x] Artikel auf Deutsch (500–1200 Wörter)
- [x] Frontmatter vollständig (title, description, pubDate, heroImage, author)
- [x] Thinkport CTA am Ende
- [x] Quellen angegeben
