### PR TITLE
Blog: Platform Engineering 2026 – Warum Internal Developer Platforms zur Pflicht werden

### DIFF
--- a/src/content/blog/platform-engineering-idp-2026.md
+++ b/src/content/blog/platform-engineering-idp-2026.md
@@ -1,0 +1,100 @@
+---
+title: "Platform Engineering 2026: Warum Internal Developer Platforms zur Pflicht werden"
+description: "Platform Engineering hat sich vom Buzzword zur strategischen Notwendigkeit entwickelt. Wir zeigen, was Internal Developer Platforms leisten, warum 80 % der Großunternehmen bis Ende 2026 dedizierte Platform Teams betreiben – und wie Sie den richtigen Einstieg finden."
+pubDate: 2026-06-26
+author: andre-lademann
+tags:
+  - Platform Engineering
+  - DevOps
+  - Kubernetes
+  - Cloud Native
+  - IDP
+  - Developer Experience
+image:
+  url: /images/blog/platform-engineering-idp-2026.png
+  alt: "Entwicklerin arbeitet an einem Internal Developer Platform Dashboard"
+---
+
+# Platform Engineering 2026: Warum Internal Developer Platforms zur Pflicht werden
+
+Die Zahlen sprechen eine klare Sprache: Laut Gartner werden **80 % der Großunternehmen bis Ende 2026 dedizierte Platform Teams** aufgestellt haben. Unternehmen, die bereits heute Internal Developer Platforms (IDPs) einsetzen, liefern Software-Updates bis zu **40 % schneller** und reduzieren ihren operativen Overhead um fast die Hälfte. Was steckt hinter diesem Trend – und was bedeutet das für Ihre Organisation?
+
+## Das Problem: DevOps allein reicht nicht mehr
+
+Wer sich an die frühen 2020er Jahre erinnert, kennt das Versprechen von DevOps: Entwicklung und Betrieb rücken zusammen, Silos werden aufgebrochen, Deployments beschleunigen sich. Das Versprechen hat sich erfüllt – aber es hat auch neue Probleme geschaffen.
+
+Mit wachsenden Teams entstanden fragmentierte Tool-Landschaften. Jedes Team betreibt eigene Pipelines, eigene Kubernetes-Konfigurationen, eigene Monitoring-Stacks. Neue Entwickler benötigen Wochen, um produktiv zu werden. Senior Engineers verbringen einen erheblichen Teil ihrer Zeit damit, Kollegen bei Infrastruktur-Fragen zu helfen statt an Features zu arbeiten.
+
+Studien zeigen: **Kognitive Überlastung** durch den Umgang mit verteilten Toolchains ist heute einer der größten Engpässe in modernen Engineering-Organisationen.
+
+## Was ist eine Internal Developer Platform?
+
+Eine Internal Developer Platform (IDP) ist keine einzelne Software, sondern ein kuratiertes Ökosystem aus Tools, Workflows und Abstraktionen, das Entwicklern ermöglicht, Infrastruktur und Deployments **selbstständig und sicher** zu steuern – ohne tiefes Ops-Wissen vorauszusetzen.
+
+Das Ziel ist klar: **Komplexität abstrahieren, ohne Kontrolle zu nehmen.**
+
+Eine gut gebaute IDP bietet:
+
+- **Self-Service-Umgebungen**: Entwickler stellen Staging- oder Feature-Branches auf Knopfdruck bereit
+- **Golden Paths**: Opinionierte, vorgefertigte Workflows, die Best Practices kodifizieren
+- **Policy-as-Code**: Sicherheit und Compliance werden automatisch durchgesetzt, nicht manuell geprüft
+- **Einheitliche Observability**: Logs, Metrics und Traces aus einer Quelle, für alle Teams gleich zugänglich
+
+## Die drei Säulen moderner Platform Engineering
+
+### 1. Developer Experience als Produkt denken
+
+Der häufigste Fehler: Platform Teams bauen eine IDP wie ein Infrastruktur-Projekt, nicht wie ein Produkt. Eine erfolgreiche Plattform verlangt nach einem **Product Mindset** – mit internen Entwicklern als Kunden, regelmäßigen Feedback-Zyklen und messbaren KPIs für Developer Satisfaction.
+
+Die Kernfrage lautet nicht „Welche Tools deployen wir?", sondern: **„Welches Problem lösen wir für unsere Entwickler?"**
+
+### 2. Golden Paths statt Freiheit ohne Grenzen
+
+Freiheit in der Tool-Wahl klingt gut, führt aber in großen Organisationen unweigerlich zu Chaos. Golden Paths sind der Ausweg: vordefinierte, empfohlene Wege für häufige Aufgaben wie das Erstellen eines neuen Microservices, das Einrichten einer CI/CD-Pipeline oder das Provisioning einer Datenbank.
+
+Ein Golden Path ist dabei kein Zwang – Teams können abweichen, wenn es einen guten Grund gibt. Er ist einfach der **schnellste und sicherste Weg** für den Standardfall. Das reduziert Cognitive Load messbar: In der Praxis berichten Organisationen von **30–40 % weniger kognitivem Overhead** nach der Einführung.
+
+### 3. Security by Default durch Policy-as-Code
+
+Security darf nicht am Ende der Pipeline als Checkliste stehen. Mit **Policy-as-Code** (Werkzeuge wie Open Policy Agent, Kyverno oder Crossplane) werden Compliance-Regeln Teil des Plattform-Codes: versioniert, testbar, automatisch durchgesetzt.
+
+Das bedeutet in der Praxis: Least-Privilege-IAM-Rollen werden automatisch zugewiesen, unsichere Container-Images werden geblockt, bevor sie je ein Cluster erreichen, und Audit-Trails entstehen ohne manuelles Zutun.
+
+## Der Einfluss von KI auf Platform Engineering
+
+2026 ist KI kein separates Thema mehr – sie ist Teil der Platform-Strategie. Laut einer aktuellen Umfrage sehen **94 % der Unternehmen KI als essenziell für den Erfolg ihrer Platform-Initiative**.
+
+Konkret bedeutet das:
+
+- **Intent-to-Infrastructure**: Entwickler beschreiben auf natürlicher Sprache, was sie brauchen – die Plattform übersetzt das in Terraform oder Helm-Charts
+- **Predictive Alerting**: ML-Modelle erkennen Anomalien, bevor sie zu Ausfällen werden
+- **AI-powered Onboarding**: Neue Entwickler werden durch die Plattform geführt, ohne Senior Engineers zu blockieren
+
+Kubernetes 1.34 hat mit **Dynamic Resource Allocation (DRA)** eine wichtige Grundlage für KI-Workloads geschaffen: Feingranulares GPU-Scheduling mit topologie-bewusstem Resource Claiming macht es möglich, Large Language Models und klassische Microservices auf denselben Clustern effizient zu betreiben.
+
+## Einstieg: Der MVP-Ansatz für Platform Engineering
+
+Der größte Fehler ist der Versuch, eine vollständige Plattform auf einmal zu bauen. Erfolgreiche Teams starten mit einem **Minimum Viable Platform (MVP)**:
+
+1. **Schritt 1 – Schmerz identifizieren**: Welche wiederkehrenden Aufgaben kosten Entwickler am meisten Zeit? Meist ist es Environment Provisioning oder CI/CD-Konfiguration.
+2. **Schritt 2 – Golden Path für einen Use Case definieren**: Einen einzigen Workflow automatisieren und als Self-Service anbieten.
+3. **Schritt 3 – Feedback messen**: Developer Satisfaction Scores (z. B. via DORA-Metriken oder einfache Team-Surveys) erheben und iterieren.
+4. **Schritt 4 – Governance einbauen**: Erst wenn der erste Path stabil ist, Policy-as-Code schrittweise einführen.
+5. **Schritt 5 – Skalieren**: Weitere Use Cases und Teams onboarden.
+
+## Fazit: Platform Engineering ist keine Option mehr
+
+Die Verschiebung ist eindeutig: Platform Engineering ist keine Kür für Tech-Giants wie Google oder Spotify mehr. Es ist die **Antwort auf die Komplexität**, die moderne Cloud-Native-Architekturen unweigerlich mitbringen.
+
+Organisationen, die heute investieren, sichern sich einen strukturellen Vorteil: schnellere Releases, weniger Incidents, glücklichere Entwickler – und eine Infrastruktur, die KI-Workloads von morgen tragen kann.
+
+Bei **Thinkport** unterstützen wir Unternehmen dabei, Platform Engineering nicht als isoliertes IT-Projekt zu starten, sondern als strategische Fähigkeit aufzubauen – mit klarer Roadmap, pragmatischem MVP-Ansatz und dem Fokus auf messbare Developer Experience.
+
+**Bereit, den ersten Schritt zu gehen?** Sprechen Sie uns an – wir zeigen Ihnen, wie eine Internal Developer Platform für Ihre spezifische Organisations- und Technologiestruktur aussieht.
+
+---
+
+*Weiterführende Quellen:*
+- [CNCF: Cloud native is now AI-native](https://www.cncf.io/blog/2026/06/02/cloud-native-is-now-ai-native-engineering-production-ready-ai/)
+- [Platform Engineering Guide 2026 – DevOpsTales](https://devopstales.com/devops/platform-engineering-guide-2026/)
+- [Fairwinds: 2026 Kubernetes Playbook](https://www.fairwinds.com/blog/2026-kubernetes-playbook-ai-self-healing-clusters-growth)


### PR DESCRIPTION
## Neuer Blogartikel: Platform Engineering 2026

### Zusammenfassung
Dieser PR fügt einen neuen Blogartikel über Platform Engineering und Internal Developer Platforms (IDPs) hinzu.

**Datei:** `src/content/blog/platform-engineering-idp-2026.md`

### Inhalt
- Warum DevOps allein 2026 nicht mehr ausreicht
- Was eine Internal Developer Platform ist und leistet
- Die drei Säulen moderner Platform Engineering (Developer Experience, Golden Paths, Policy-as-Code)
- Einfluss von KI auf Platform Engineering (inkl. Kubernetes 1.34 DRA)
- Praxisnaher MVP-Einstiegsansatz in 5 Schritten

### Zielgruppe
IT-Entscheider, Cloud-Architekten und DevOps-Engineers in Deutschland

### Metadaten
- **Autor:** andre-lademann
- **Datum:** 2026-06-26
- **Tags:** Platform Engineering, DevOps, Kubernetes, Cloud Native, IDP, Developer Experience
- **Wortanzahl:** ~900 Wörter

### Image Prompt (für Hero-Bild)
> A developer working at a modern dashboard showing an internal developer platform with Kubernetes cluster visualizations, golden path workflows, and AI-powered infrastructure provisioning. Clean, minimalist design in blue and teal tones. Professional tech environment. 16:9 format.

### Checklist
- [x] Artikel auf Deutsch verfasst
- [x] Frontmatter vollständig (title, description, pubDate, author, tags, image)
- [x] Quellen verlinkt
- [x] Länge: 500–1200 Wörter ✓
- [x] Thema recherchiert und aktuell (2026)
